### PR TITLE
✨ Add IModel generation for Items that are not in Collections

### DIFF
--- a/changes/20250404155011.feature
+++ b/changes/20250404155011.feature
@@ -1,0 +1,1 @@
+:sparkle: Add IMethod generation for Items that are not in Collections

--- a/generator/codegen/common.go
+++ b/generator/codegen/common.go
@@ -26,9 +26,11 @@ var (
 )
 
 const (
-	schemaPrefix   = "#/components/schemas/"
-	jsonMIME       = "application/json"
+	schemaPrefix = "#/components/schemas/"
+	jsonMIME     = "application/json"
+	// See https://github.com/Arm-Debug/API-Uniform-Contract?tab=readme-ov-file#api-extensions
 	redactFlag     = "x-redact"
+	jobFlag        = "x-job"
 	collectionFlag = "x-collection"
 )
 

--- a/generator/codegen/jobitem_extensions.go
+++ b/generator/codegen/jobitem_extensions.go
@@ -1,7 +1,6 @@
 package codegen
 
 import (
-	"encoding/json"
 	"slices"
 	"strings"
 
@@ -18,10 +17,6 @@ type JobItems = []JobItem
 type JobItemsParams = struct {
 	JobItems
 }
-
-const (
-	JobItemName = "x-job" // See https://github.com/Arm-Debug/API-Uniform-Contract?tab=readme-ov-file#api-extensions
-)
 
 func AddJobItemsToParams(d *Data) (err error) {
 	return AddValuesToParams(d, func(swagger *openapi3.T) (interface{}, error) { return GetJobItems(swagger) }, "jobs.go")
@@ -45,14 +40,12 @@ func GetJobItems(swagger *openapi3.T) (jobItems JobItemsParams, err error) {
 			continue
 		}
 
-		var isExtendedJobItem bool
-		if c, ok := schemaVal.ExtensionProps.Extensions[JobItemName].(json.RawMessage); ok {
-			err = json.Unmarshal(c, &isExtendedJobItem)
-			if err != nil {
-				return
-			}
+		isJobItem, subErr := isExtensionFlagSet(schemaVal.ExtensionProps, jobFlag)
+		if subErr != nil {
+			err = subErr
+			return
 		}
-		if isExtendedJobItem {
+		if isJobItem {
 			jobs = append(jobs, JobItem{schemaName})
 		}
 	}

--- a/generator/codegen/templates/entities.go.tmpl
+++ b/generator/codegen/templates/entities.go.tmpl
@@ -140,6 +140,35 @@ func New{{ .CollectionRef }}Collection() IStaticPage {
 	return New{{ .CollectionRef }}WithDefaults()
 }
 {{ end }}
+{{ range .JobItems -}}
+// ============================================================================================
+// This extends {{ .JobItemSchema }} definitions
+// ============================================================================================
+// FetchType returns the resource type
+func (o *{{ .JobItemSchema }}) FetchType() string {
+	return "{{ .JobItemSchema }}"
+}
+
+// FetchLinks returns the resource links if present
+func (o *{{ .JobItemSchema }}) FetchLinks() (links any, err error) {
+	if !o.Links.IsSet() {
+		err = errors.New("missing links")
+		return
+	}
+	links = o.GetLinks()
+	return
+}
+
+// FetchName returns the resource name if present, or else an error
+func (o *{{ .JobItemSchema }}) FetchName() (string, error) {
+	return o.GetName(), nil
+}
+
+// FetchTitle returns the resource title if present, or else an error
+func (o *{{ .JobItemSchema }}) FetchTitle() (string, error) {
+	return o.GetTitle(), nil
+}
+{{ end }}
 {{ range .MessageCollections -}}
 // ============================================================================================
 // This extends {{ .ItemRef }} definitions


### PR DESCRIPTION
<!--
Copyright (C) 2020-2022 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Proprietary
-->
### Description
The only Items that get extended to implement IModel are Items inside Collections, which is not the exclusive list of Items we want to extend, some `x-job` Items are defined but not in a collection.
This changes generates `IModel` methods to job items that are not in Collections.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [X]  Additional tests are not required for this change (e.g. documentation update).
